### PR TITLE
Fix needle_sharing provenance docs; note possible source

### DIFF
--- a/R/data-needle_sharing.R
+++ b/R/data-needle_sharing.R
@@ -7,8 +7,11 @@
 #' study is not documented in the textbook or the companion materials, so no
 #' primary article or study design is cited here. One possible (though
 #' unconfirmed) source is Tsui et al. (2009),
-#' \doi{10.1016/j.drugalcdep.2009.05.022} — a study of injection drug users in
-#' San Francisco co-authored by RMB author E. Vittinghoff.
+#' \doi{10.1016/j.drugalcdep.2009.05.022} -- a study of injection drug users in
+#' San Francisco co-authored by RMB author E. Vittinghoff. The match is
+#' uncertain because this dataset lacks an HCV variable (Tsui et al. studied
+#' HCV seroconversion) and its mean participant age (~40) is older than that
+#' paper's young-IDU cohort.
 #'
 #' @format A data frame with 128 rows and 17 variables:
 #' \describe{

--- a/R/data-needle_sharing.R
+++ b/R/data-needle_sharing.R
@@ -5,7 +5,10 @@
 #' [UCSF companion website](https://regression.ucsf.edu/second-edition/data-examples-and-problems).
 #' As distributed, the data are one row per participant (n = 128); the original
 #' study is not documented in the textbook or the companion materials, so no
-#' primary article or study design is cited here.
+#' primary article or study design is cited here. One possible (though
+#' unconfirmed) source is Tsui et al. (2009),
+#' \doi{10.1016/j.drugalcdep.2009.05.022} — a study of injection drug users in
+#' San Francisco co-authored by RMB author E. Vittinghoff.
 #'
 #' @format A data frame with 128 rows and 17 variables:
 #' \describe{

--- a/R/data-needle_sharing.R
+++ b/R/data-needle_sharing.R
@@ -7,7 +7,7 @@
 #' study is not documented in the textbook or the companion materials, so no
 #' primary article or study design is cited here. One possible (though
 #' unconfirmed) source is Tsui et al. (2009),
-#' \doi{10.1016/j.drugalcdep.2009.05.022} -- a study of injection drug users in
+#' \doi{10.1016/j.drugalcdep.2009.05.022} --- a study of injection drug users in
 #' San Francisco co-authored by RMB author E. Vittinghoff. The match is
 #' uncertain because this dataset lacks an HCV variable (Tsui et al. studied
 #' HCV seroconversion) and its mean participant age (~40) is older than that

--- a/R/data-needle_sharing.R
+++ b/R/data-needle_sharing.R
@@ -1,9 +1,11 @@
 #' Needle sharing data
 #'
-#' Dataset used in Chapter 8 of *Regression Methods in Biostatistics*
-#' (2nd edition), as distributed on the UCSF companion website.
-#' Study design: Longitudinal panel study of injection drug users measuring repeated needle-sharing behavior.
-#' Primary article: [RMB2e risky-drug-use example dataset](https://regression.ucsf.edu/second-edition/data-examples-and-problems).
+#' The risky-drug-use (needle-sharing) example dataset from Chapter 8 of
+#' *Regression Methods in Biostatistics* (2nd edition), distributed on the
+#' [UCSF companion website](https://regression.ucsf.edu/second-edition/data-examples-and-problems).
+#' As distributed, the data are one row per participant (n = 128); the original
+#' study is not documented in the textbook or the companion materials, so no
+#' primary article or study design is cited here.
 #'
 #' @format A data frame with 128 rows and 17 variables:
 #' \describe{

--- a/man/needle_sharing.Rd
+++ b/man/needle_sharing.Rd
@@ -40,7 +40,7 @@ As distributed, the data are one row per participant (n = 128); the original
 study is not documented in the textbook or the companion materials, so no
 primary article or study design is cited here. One possible (though
 unconfirmed) source is Tsui et al. (2009),
-\doi{10.1016/j.drugalcdep.2009.05.022} -- a study of injection drug users in
+\doi{10.1016/j.drugalcdep.2009.05.022} --- a study of injection drug users in
 San Francisco co-authored by RMB author E. Vittinghoff. The match is
 uncertain because this dataset lacks an HCV variable (Tsui et al. studied
 HCV seroconversion) and its mean participant age (~40) is older than that

--- a/man/needle_sharing.Rd
+++ b/man/needle_sharing.Rd
@@ -38,6 +38,9 @@ The risky-drug-use (needle-sharing) example dataset from Chapter 8 of
 \href{https://regression.ucsf.edu/second-edition/data-examples-and-problems}{UCSF companion website}.
 As distributed, the data are one row per participant (n = 128); the original
 study is not documented in the textbook or the companion materials, so no
-primary article or study design is cited here.
+primary article or study design is cited here. One possible (though
+unconfirmed) source is Tsui et al. (2009),
+\doi{10.1016/j.drugalcdep.2009.05.022} — a study of injection drug users in
+San Francisco co-authored by RMB author E. Vittinghoff.
 }
 \keyword{datasets}

--- a/man/needle_sharing.Rd
+++ b/man/needle_sharing.Rd
@@ -40,7 +40,10 @@ As distributed, the data are one row per participant (n = 128); the original
 study is not documented in the textbook or the companion materials, so no
 primary article or study design is cited here. One possible (though
 unconfirmed) source is Tsui et al. (2009),
-\doi{10.1016/j.drugalcdep.2009.05.022} — a study of injection drug users in
-San Francisco co-authored by RMB author E. Vittinghoff.
+\doi{10.1016/j.drugalcdep.2009.05.022} -- a study of injection drug users in
+San Francisco co-authored by RMB author E. Vittinghoff. The match is
+uncertain because this dataset lacks an HCV variable (Tsui et al. studied
+HCV seroconversion) and its mean participant age (~40) is older than that
+paper's young-IDU cohort.
 }
 \keyword{datasets}

--- a/man/needle_sharing.Rd
+++ b/man/needle_sharing.Rd
@@ -33,9 +33,11 @@ A data frame with 128 rows and 17 variables:
 needle_sharing
 }
 \description{
-Dataset used in Chapter 8 of \emph{Regression Methods in Biostatistics}
-(2nd edition), as distributed on the UCSF companion website.
-Study design: Longitudinal panel study of injection drug users measuring repeated needle-sharing behavior.
-Primary article: \href{https://regression.ucsf.edu/second-edition/data-examples-and-problems}{RMB2e risky-drug-use example dataset}.
+The risky-drug-use (needle-sharing) example dataset from Chapter 8 of
+\emph{Regression Methods in Biostatistics} (2nd edition), distributed on the
+\href{https://regression.ucsf.edu/second-edition/data-examples-and-problems}{UCSF companion website}.
+As distributed, the data are one row per participant (n = 128); the original
+study is not documented in the textbook or the companion materials, so no
+primary article or study design is cited here.
 }
 \keyword{datasets}


### PR DESCRIPTION
The `needle_sharing` roxygen doc asserted the data came from a *"Longitudinal panel study of injection drug users measuring repeated needle-sharing behavior"* and linked a *"Primary article."* Neither is supported.

## Why
Tracing the provenance, every layer cites **no** primary study:
- Textbook §8.3.1 (RMB2e Ch. 8) — presents it as a teaching example, no citation.
- The UCSF companion website (the actual data source) — download link only, no attribution.
- The `.dta` file — no embedded label/notes/citation.

The data as distributed is also **one row per participant** (n = 128, a single 30-day window), not repeated measures — so "longitudinal panel study … repeated behavior" is inconsistent with the data itself.

## Changes
- Replace the unsourced study-design/primary-article lines with a factual UCSF-source description and an explicit note that the original study is undocumented.
- Drop the misleading "Primary article" link (it pointed to the companion *data* page, not an article).
- Add a **possible (unconfirmed) source**: Tsui JI, Vittinghoff E, Hahn JA, et al. "Risk behaviors after hepatitis C virus seroconversion in young injection drug users in San Francisco." *Drug Alcohol Depend.* 2009;105(1-2):160-3 — https://www.sciencedirect.com/science/article/pii/S0376871609002294 (doi:10.1016/j.drugalcdep.2009.05.022). Notable as a San Francisco IDU study co-authored by RMB author E. Vittinghoff; flagged unconfirmed (our data has no HCV variable and mean age ~40, vs. that paper's young HCV cohort).
- Regenerate `man/needle_sharing.Rd`.

Docs-only; no data change. Companion change to the rme chapter: d-morrison/rme#860.

🤖 Generated with [Claude Code](https://claude.com/claude-code)